### PR TITLE
Load vc-git for using vc-git-root

### DIFF
--- a/gitty.el
+++ b/gitty.el
@@ -43,6 +43,8 @@
 
 ;;; Code:
 
+(require 'vc-git)
+
 (defvar gitty-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-x v b") 'gitty-checkout)


### PR DESCRIPTION
There is following byte-compile warning.

```
In end of data:
gitty.el:149:1:Warning: the function `vc-git-root' is not known to be defined.
```